### PR TITLE
Perform splitting and recovery on a V8 background thread

### DIFF
--- a/native/src/sss.rs
+++ b/native/src/sss.rs
@@ -1,14 +1,58 @@
 use std::error::Error;
 
+use neon::task::Task;
+use neon::scope::Scope;
 use neon::vm::{Call, JsResult, Lock};
 use neon::js::binary::JsBuffer;
-use neon::js::error::{JsError, Kind};
-use neon::js::{JsArray, JsBoolean, JsFunction, JsInteger, JsNull, JsString, JsUndefined, Object,
-               ToJsString, Value};
+use neon::js::error::{throw, JsError, Kind};
+use neon::js::{JsArray, JsBoolean, JsFunction, JsInteger, JsString, JsUndefined, Object,
+               ToJsString};
 
+use rusty_secrets;
 use rusty_secrets::sss;
 
 use util::{recovery_error_to_js, to_u8};
+
+struct SplitSecretTask {
+    threshold: u8,
+    shares_count: u8,
+    secret: Vec<u8>,
+    sign_shares: bool,
+}
+
+impl Task for SplitSecretTask {
+    type Output = Vec<String>;
+    type Error = rusty_secrets::errors::Error;
+    type JsEvent = JsArray;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        sss::split_secret(
+            self.threshold,
+            self.shares_count,
+            self.secret.as_slice(),
+            self.sign_shares,
+        )
+    }
+
+    fn complete<'a, T: Scope<'a>>(
+        self,
+        scope: &'a mut T,
+        result: Result<Self::Output, Self::Error>,
+    ) -> JsResult<Self::JsEvent> {
+        match result {
+            Ok(shares) => {
+                let output = JsArray::new(scope, shares.len() as u32);
+
+                for (i, share) in shares.into_iter().enumerate() {
+                    output.set(i as u32, share.as_str().to_js_string(scope))?;
+                }
+
+                Ok(output)
+            }
+            Err(err) => JsError::throw(Kind::Error, err.description()),
+        }
+    }
+}
 
 pub fn split_secret(call: Call) -> JsResult<JsUndefined> {
     let scope = call.scope;
@@ -16,7 +60,7 @@ pub fn split_secret(call: Call) -> JsResult<JsUndefined> {
     let threshold_handle = args.require(scope, 0)?;
     let shares_count_handle = args.require(scope, 1)?;
     let secret_handle = args.require(scope, 2)?;
-    let sign_handle = args.require(scope, 3)?;
+    let sign_shares_handle = args.require(scope, 3)?;
     let cb_handle = args.require(scope, 4)?;
 
     let threshold = to_u8(
@@ -30,40 +74,62 @@ pub fn split_secret(call: Call) -> JsResult<JsUndefined> {
     )?;
 
     let cb = cb_handle.check::<JsFunction>()?;
-    let sign = sign_handle.check::<JsBoolean>()?.value();
+    let sign_shares = sign_shares_handle.check::<JsBoolean>()?.value();
     let secret = secret_handle
         .check::<JsBuffer>()?
         .grab(|contents| contents.as_slice().to_vec());
 
-    let (result, err) = match sss::split_secret(threshold, shares_count, &secret, sign) {
-        Ok(shares) => {
-            let result = JsArray::new(scope, shares.len() as u32);
-
-            for (i, share) in shares.into_iter().enumerate() {
-                result.set(i as u32, share.as_str().to_js_string(scope))?;
-            }
-
-            (result.as_value(scope), JsNull::new().as_value(scope))
-        }
-        Err(err) => (
-            JsNull::new().as_value(scope),
-            JsError::new(scope, Kind::Error, err.description())?.as_value(scope),
-        ),
+    let task = SplitSecretTask {
+        threshold,
+        shares_count,
+        secret,
+        sign_shares,
     };
 
-    cb.call(scope, JsNull::new(), vec![err, result])?;
+    task.schedule(cb);
 
     Ok(JsUndefined::new())
+}
+
+struct RecoverSecretTask {
+    shares: Vec<String>,
+    verify_signatures: bool,
+}
+
+impl Task for RecoverSecretTask {
+    type Output = Vec<u8>;
+    type Error = rusty_secrets::errors::Error;
+    type JsEvent = JsBuffer;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        sss::recover_secret(&self.shares, self.verify_signatures)
+    }
+
+    fn complete<'a, T: Scope<'a>>(
+        self,
+        scope: &'a mut T,
+        result: Result<Self::Output, Self::Error>,
+    ) -> JsResult<Self::JsEvent> {
+        match result {
+            Ok(bytes) => {
+                let mut buffer = JsBuffer::new(scope, bytes.len() as u32)?;
+                buffer.grab(|mut contents| {
+                    contents.as_mut_slice().copy_from_slice(&bytes);
+                });
+                Ok(buffer)
+            }
+            Err(err) => throw(recovery_error_to_js(scope, &err)?),
+        }
+    }
 }
 
 pub fn recover_secret(call: Call) -> JsResult<JsUndefined> {
     let scope = call.scope;
     let args = call.arguments;
-    let shares_handle = args.require(scope, 0)?;
-    let verify_handle = args.require(scope, 1)?;
-    let cb_handle = args.require(scope, 2)?;
 
-    let js_shares = shares_handle.check::<JsArray>()?.to_vec(scope)?;
+    let js_shares = args.require(scope, 0)?.check::<JsArray>()?.to_vec(scope)?;
+    let verify_signatures = args.require(scope, 1)?.check::<JsBoolean>()?.value();
+    let cb = args.require(scope, 2)?.check::<JsFunction>()?;
 
     let mut shares = Vec::with_capacity(js_shares.len());
     for js_share in js_shares {
@@ -71,29 +137,12 @@ pub fn recover_secret(call: Call) -> JsResult<JsUndefined> {
         shares.push(share.value());
     }
 
-    let verify = verify_handle.check::<JsBoolean>()?.value();
-    let cb = cb_handle.check::<JsFunction>()?;
-
-    let secret = match sss::recover_secret(&shares, verify) {
-        Ok(bytes) => {
-            let mut buffer = JsBuffer::new(scope, bytes.len() as u32)?;
-            buffer.grab(|mut contents| {
-                contents.as_mut_slice().copy_from_slice(&bytes);
-            });
-            Ok(buffer)
-        }
-        Err(err) => Err(err),
+    let task = RecoverSecretTask {
+        shares,
+        verify_signatures,
     };
 
-    let (result, err) = match secret {
-        Ok(secret) => (secret.as_value(scope), JsNull::new().as_value(scope)),
-        Err(err) => (
-            JsNull::new().as_value(scope),
-            recovery_error_to_js(scope, &err)?.as_value(scope),
-        ),
-    };
-
-    cb.call(scope, JsNull::new(), vec![err, result])?;
+    task.schedule(cb);
 
     Ok(JsUndefined::new())
 }

--- a/native/src/wrapped.rs
+++ b/native/src/wrapped.rs
@@ -1,16 +1,61 @@
 use std::error::Error;
 
+use neon::task::Task;
 use neon::scope::Scope;
 use neon::vm::{Call, JsResult, Lock};
 use neon::js::binary::JsBuffer;
-use neon::js::error::{JsError, Kind};
+use neon::js::error::{throw, JsError, Kind};
 use neon::js::{JsArray, JsBoolean, JsFunction, JsInteger, JsNull, JsObject, JsString, JsUndefined,
                Object, ToJsString, Value};
 
+use rusty_secrets;
 use rusty_secrets::wrapped_secrets;
 use rusty_secrets::proto::wrapped::SecretProto;
 
 use util::{recovery_error_to_js, to_u8};
+
+struct SplitSecretTask {
+    threshold: u8,
+    shares_count: u8,
+    secret: Vec<u8>,
+    mime_type: Option<String>,
+    sign_shares: bool,
+}
+
+impl Task for SplitSecretTask {
+    type Output = Vec<String>;
+    type Error = rusty_secrets::errors::Error;
+    type JsEvent = JsArray;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        wrapped_secrets::split_secret(
+            self.threshold,
+            self.shares_count,
+            self.secret.as_slice(),
+            self.mime_type.clone(),
+            self.sign_shares,
+        )
+    }
+
+    fn complete<'a, T: Scope<'a>>(
+        self,
+        scope: &'a mut T,
+        result: Result<Self::Output, Self::Error>,
+    ) -> JsResult<Self::JsEvent> {
+        match result {
+            Ok(shares) => {
+                let output = JsArray::new(scope, shares.len() as u32);
+
+                for (i, share) in shares.into_iter().enumerate() {
+                    output.set(i as u32, share.as_str().to_js_string(scope))?;
+                }
+
+                Ok(output)
+            }
+            Err(err) => JsError::throw(Kind::Error, err.description()),
+        }
+    }
+}
 
 pub fn split_secret(call: Call) -> JsResult<JsUndefined> {
     let scope = call.scope;
@@ -19,7 +64,7 @@ pub fn split_secret(call: Call) -> JsResult<JsUndefined> {
     let shares_count_handle = args.require(scope, 1)?;
     let secret_handle = args.require(scope, 2)?;
     let mime_type_handle = args.require(scope, 3)?;
-    let sign_handle = args.require(scope, 4)?;
+    let sign_shares_handle = args.require(scope, 4)?;
     let cb_handle = args.require(scope, 5)?;
 
     let threshold = to_u8(
@@ -34,41 +79,57 @@ pub fn split_secret(call: Call) -> JsResult<JsUndefined> {
 
     let cb = cb_handle.check::<JsFunction>()?;
     let mime_type = mime_type_handle.downcast::<JsString>().map(|s| s.value());
-    let sign = sign_handle.check::<JsBoolean>()?.value();
+    let sign_shares = sign_shares_handle.check::<JsBoolean>()?.value();
     let secret = secret_handle
         .check::<JsBuffer>()?
         .grab(|contents| contents.as_slice().to_vec());
 
-    let (result, err) =
-        match wrapped_secrets::split_secret(threshold, shares_count, &secret, mime_type, sign) {
-            Ok(shares) => {
-                let result = JsArray::new(scope, shares.len() as u32);
+    let task = SplitSecretTask {
+        threshold,
+        shares_count,
+        secret,
+        mime_type,
+        sign_shares,
+    };
 
-                for (i, share) in shares.into_iter().enumerate() {
-                    result.set(i as u32, share.as_str().to_js_string(scope))?;
-                }
-
-                (result.as_value(scope), JsNull::new().as_value(scope))
-            }
-            Err(err) => (
-                JsNull::new().as_value(scope),
-                JsError::new(scope, Kind::Error, err.description())?.as_value(scope),
-            ),
-        };
-
-    cb.call(scope, JsNull::new(), vec![err, result])?;
+    task.schedule(cb);
 
     Ok(JsUndefined::new())
+}
+
+struct RecoverSecretTask {
+    shares: Vec<String>,
+    verify_signatures: bool,
+}
+
+impl Task for RecoverSecretTask {
+    type Output = SecretProto;
+    type Error = rusty_secrets::errors::Error;
+    type JsEvent = JsObject;
+
+    fn perform(&self) -> Result<Self::Output, Self::Error> {
+        wrapped_secrets::recover_secret(&self.shares, self.verify_signatures)
+    }
+
+    fn complete<'a, T: Scope<'a>>(
+        self,
+        scope: &'a mut T,
+        result: Result<Self::Output, Self::Error>,
+    ) -> JsResult<Self::JsEvent> {
+        match result {
+            Ok(proto) => proto_to_js_obj(scope, &proto),
+            Err(err) => throw(recovery_error_to_js(scope, &err)?),
+        }
+    }
 }
 
 pub fn recover_secret(call: Call) -> JsResult<JsUndefined> {
     let scope = call.scope;
     let args = call.arguments;
-    let shares_handle = args.require(scope, 0)?;
-    let verify_handle = args.require(scope, 1)?;
-    let cb_handle = args.require(scope, 2)?;
 
-    let js_shares = shares_handle.check::<JsArray>()?.to_vec(scope)?;
+    let js_shares = args.require(scope, 0)?.check::<JsArray>()?.to_vec(scope)?;
+    let verify_signatures = args.require(scope, 1)?.check::<JsBoolean>()?.value();
+    let cb = args.require(scope, 2)?.check::<JsFunction>()?;
 
     let mut shares = Vec::with_capacity(js_shares.len());
     for js_share in js_shares {
@@ -76,21 +137,12 @@ pub fn recover_secret(call: Call) -> JsResult<JsUndefined> {
         shares.push(share.value());
     }
 
-    let verify = verify_handle.check::<JsBoolean>()?.value();
-    let cb = cb_handle.check::<JsFunction>()?;
-
-    let (secret, err) = match wrapped_secrets::recover_secret(&shares, verify) {
-        Ok(proto) => (
-            proto_to_js_obj(scope, &proto)?.as_value(scope),
-            JsNull::new().as_value(scope),
-        ),
-        Err(err) => (
-            JsNull::new().as_value(scope),
-            recovery_error_to_js(scope, &err)?.as_value(scope),
-        ),
+    let task = RecoverSecretTask {
+        shares,
+        verify_signatures,
     };
 
-    cb.call(scope, JsNull::new(), vec![err, secret])?;
+    task.schedule(cb);
 
     Ok(JsUndefined::new())
 }


### PR DESCRIPTION
Doing this lets us avoid blocking the main thread for the ~100ms that splitting and recovery take.